### PR TITLE
Update command text casing to match VS Code style

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Display a specified file in hexadecimal
 
 ## Main Features
 
-Right-click on a file in the explorer to see *Show hexdump for file*  
+Right-click on a file in the explorer to see *Show Hexdump*  
 ![Show hexdump](images/show-hexdump.png)
 
 Hover in the data section to see numerical values  
@@ -24,10 +24,10 @@ Right-click in the hexdump to see more options
 
 ## Commands
 
-* `hexdumpFile` (`ctrl+shift+alt+h`, `cmd+shift+alt+h`) Show hexdump for file
-* `editValue` (`shift+enter`) Edit the value under the cursor
-* `gotoAddress` (`ctrl+g`) Go to a specific address
-* `exportToFile` (`ctrl+s`, `cmd+s`) Export to a binary file
+* `hexdumpFile` (`ctrl+shift+alt+h`, `cmd+shift+alt+h`) Show Hexdump
+* `editValue` (`shift+enter`) Edit Value Under Cursor
+* `gotoAddress` (`ctrl+g`) Go to Address...
+* `exportToFile` (`ctrl+s`, `cmd+s`) Export to Binary File...
 
 ## Configuration
 
@@ -37,13 +37,13 @@ Right-click in the hexdump to see more options
 * `hexdump.width` Number of bytes per line (8, 16, 32)
 * `hexdump.showOffset` Show offset on first line
 * `hexdump.showAddress` Show address on each line
-* `hexdump.showAscii` Show ascii section
+* `hexdump.showAscii` Show ASCII section
 
 ## Installation
 
 1. Install *Visual Studio Code* (1.7.0 or higher)
 2. Launch *Code*
-3. From the command palette `Ctrl-Shift-P` (Windows, Linux) or `Cmd-Shift-P` (OSX)
+3. From the command palette `ctrl+shift+p` (Windows, Linux) or `cmd+shift+p` (OS X)
 4. Select `Install Extension`
 5. Choose the extension `hexdump for VSCode`
 6. Reload *Visual Studio Code*

--- a/package.json
+++ b/package.json
@@ -50,26 +50,26 @@
     "commands": [
       {
         "command": "hexdump.hexdumpFile",
-        "title": "Show hexdump for file"
+        "title": "Show Hexdump"
       },
       {
         "command": "hexdump.editValue",
-        "title": "Edit the value under the cursor",
+        "title": "Edit Value Under Cursor",
         "when": "editorLangId == hexdump"
       },
       {
         "command": "hexdump.gotoAddress",
-        "title": "Go to a specific address",
+        "title": "Go to Address...",
         "when": "editorLangId == hexdump"
       },
       {
         "command": "hexdump.exportToFile",
-        "title": "Export to a binary file",
+        "title": "Export to Binary File...",
         "when": "editorLangId == hexdump"
       },
       {
         "command": "hexdump.toggleEndian",
-        "title": "Toggle between little and big endian",
+        "title": "Toggle Between Little and Big Endian",
         "when": "editorLangId == hexdump"
       }
     ],
@@ -146,7 +146,7 @@
           "minimum": 2,
           "maximum": 4,
           "default": 2,
-          "description": "how many nibbles per group"
+          "description": "How many nibbles per group"
         },
         "hexdump.uppercase": {
           "type": "boolean",
@@ -158,7 +158,7 @@
           "minimum": 8,
           "maximum": 32,
           "default": 16,
-          "description": "number of bytes per line"
+          "description": "Number of bytes per line"
         },
         "hexdump.showOffset": {
           "type": "boolean",
@@ -173,7 +173,7 @@
         "hexdump.showAscii": {
           "type": "boolean",
           "default": true,
-          "description": "Show ascii section"
+          "description": "Show ASCII section"
         }
       }
     }


### PR DESCRIPTION
Most context-menu items are in title-case, from what I can tell. This change allows hexdump's to fit in more naturally with existing commands, along with some other minor consistency corrections.