### PR TITLE
fix copy as JSON

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -520,7 +520,7 @@ export function activate(context: vscode.ExtensionContext) {
         let e = vscode.window.activeTextEditor;
         let buffer = getBufferSelection(e.document, e.selection);
         if (buffer) {
-            clipboardy.write(buffer.toJSON().toString());
+            clipboardy.write(JSON.stringify(buffer));
         }
     }));
 


### PR DESCRIPTION
The result in the current version ( `1.7.2` ) will always be `[object Object]`