### PR TITLE
Fix update on save and on file changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 out
 node_modules
+package-lock.json

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -315,13 +315,19 @@ export function activate(context: vscode.ExtensionContext) {
             return;
         }
 
+        var entry = getEntry(d.uri);
         let filepath = getPhysicalPath(d.uri);
-        var buf = getBuffer(d.uri);
+        var buf = entry.buffer;
         fs.writeFile(filepath, buf, (err) => {
             if (err) {
                 return vscode.window.setStatusBarMessage('Hexdump: ERROR ' + err, 3000);
             }
 
+            entry.isDirty = false;
+            entry.decorations = [];
+            provider.update(d.uri);
+            statusBar.update();
+            triggerUpdateDecorations(e);
             vscode.window.setStatusBarMessage('Hexdump: exported to ' + filepath, 3000);
         });
 


### PR DESCRIPTION
I fixed some issues regarding updating the hex dump of the edited files.
For example, #66 and #17.
I changed the usage of fs.watch function and it can now update the dump after the source file is changed (probably by other application).
Also, the decorations and status bar will be updated after the file is saved.
