### PR TITLE
adding endianness, radix, and bitness; fixing external file updates and few other small bugs;

### DIFF
--- a/.vscode/tasks.json.old
+++ b/.vscode/tasks.json.old
@@ -8,10 +8,16 @@
 
 // A task runner that calls a custom npm script that compiles the extension.
 {
-    "version": "2.0.0",
+    "version": "0.1.0",
 
     // we want to run npm
     "command": "npm",
+
+    // the command is a shell script
+    "isShellCommand": true,
+
+    // show the output window only if unrecognized errors occur.
+    "showOutput": "silent",
 
     // we run the custom script "compile" as defined in package.json
     "args": ["run", "compile", "--loglevel", "silent"],
@@ -20,24 +26,5 @@
     "isWatching": true,
 
     // use the standard tsc in watch mode problem matcher to find compile problems in the output.
-    "problemMatcher": "$tsc-watch",
-    "tasks": [
-        {
-            "label": "npm",
-            "type": "shell",
-            "command": "npm",
-            "args": [
-                "run",
-                "compile",
-                "--loglevel",
-                "silent"
-            ],
-            "isBackground": true,
-            "problemMatcher": "$tsc-watch",
-            "group": {
-                "_id": "build",
-                "isDefault": false
-            }
-        }
-    ]
+    "problemMatcher": "$tsc-watch"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.8.0] TBD
+## [1.9.0] TBD
 ++ endianness, ++ radix, ++ data size; -- few small bugs;
 details:
 * Enabled endianness of displayed data (the main reason behind the change) enabled by the added feature to hexy.js
@@ -13,9 +13,12 @@ details:
 * Build: fixed build by providing `null` arguments into `resolve()` -- the method requires one argument now
 * Dependency: now depending on hexy.js 0.3.3 (unpublished yet), which supports endianness and radix
 
+## [1.8.0] 2020-09-10
+* Fix update on save and on file changed (#17, [#66](https://github.com/stef-levesque/vscode-hexdump/issues/66), [#67](https://github.com/stef-levesque/vscode-hexdump/issues/67), thanks @joeywang4)
+
 ## [1.7.0] 2018-10-08
-* Copy selection in different formats (#41, #43, #47)
-* Add support for multi byte edit (#42, #45, thanks @noam787)
+* Copy selection in different formats (#41, [#43](https://github.com/stef-levesque/vscode-hexdump/issues/43), [#47](https://github.com/stef-levesque/vscode-hexdump/issues/47))
+* Add support for multi byte edit (#42, [#45](https://github.com/stef-levesque/vscode-hexdump/issues/45), thanks @noam787)
 * Fix `exportToFile` (#46)
 * Search a HEX string in the file (#48, thanks @jinliming2)
 
@@ -64,7 +67,7 @@ details:
 
 * Customizable value for size warning and line count (#9)
 * Add icon to title context menu (#10)
-* Command text and changelog update (#11, #12, thanks @david-russo)
+* Command text and changelog update (#11, [#12](https://github.com/stef-levesque/vscode-hexdump/issues/12), thanks @david-russo)
 
 ## [1.1.1] 2016-10-25
 
@@ -77,10 +80,10 @@ details:
 
 ## [1.0.0] 2016-10-10
 
-* Update if file changes (#2, #3, thanks @camwar11)
+* Update if file changes (#2, [#3](https://github.com/stef-levesque/vscode-hexdump/issues/3), thanks @camwar11)
 * Switch to [hexy.js](https://www.npmjs.com/package/hexy) (#4, thanks @boguscoder)
 * Highlight selection in both hex and ascii sections (#6)
-* More display options (see Configuration) (#5, #7)
+* More display options (see Configuration) (#5, [#7](https://github.com/stef-levesque/vscode-hexdump/issues/7))
 
 ## [0.1.1] 2016-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,20 @@ details:
 * Context Menu: added convenient switch of displaying between 1, 2, 4 and 8 byte words
 * New Fx: added ability to display bytes as binary, octal, decimal and hexadecimal
 * New Fx (issue #59): each file can have its own view settings
+* New Fx: the file view settings are now persistent through the app sessions
 * Context Menu: the above functionality is also accessible via the context menu
 * Bugfix: endiannes was always set to "big", regardless of the UI setting in multi-byte displaying
 * Bugfix: fixed the meaning of endiannes that was incorrectly displayed in the status bar
 * Bugfix: the popup tooltip was showing value of the sequence starting with the byte under cursor, as opposed to the value displayed under the cursor.  This change doesn't affect the 2-nibble (one byte) display mode (need before and after screenshots)
 * Bugfix (#79): better tracking of externally modified and deleted files
 * Bugfix (#77): correctly handling tab closure and therefore removing incorrect data persistency through tab closure and reopening
+* Fixes in hover window:
+  * corrected offset calculation for LE mode
+  * Int64 and Uint64 values were always the same regardless the position of the cursor
+  * Int64 and Uint64 were swapped around: uint was read as signed, and int was read as unsigned
 * Build: fixed build by providing `null` arguments into `resolve()` -- the method requires one argument now
 * Dependency: now depending on hexy 0.3.4, which supports endianness and radix
-* Dependency: no longer depending on `clipboardly` and native `fs` object -- replaced by vscode's alternatives that work better (some of the bugfixes above are attributed to this)
+* Dependency: no longer depending on `clipboardly`, `sprintf-js`, and native `fs` objects -- replaced by vscode's alternatives that work better (some of the bugfixes above are attributed to this)
 * Fit and Finish: removed the "Show Hexdump" menu items from hexdump tabs
 * Version: updated version number
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,19 @@
 details:
 * Enabled endianness of displayed data (the main reason behind the change) enabled by the added feature to hexy.js
 * Context Menu: added convenient switch of displaying between 1, 2, 4 and 8 byte words
-* New Functionality: added ability to display bytes as binary, octal, decimal and hexadecimal
+* New Fx: added ability to display bytes as binary, octal, decimal and hexadecimal
+* New Fx (issue #59): each file can have its own view settings
 * Context Menu: the above functionality is also accessible via the context menu
 * Bugfix: endiannes was always set to "big", regardless of the UI setting in multi-byte displaying
 * Bugfix: fixed the meaning of endiannes that was incorrectly displayed in the status bar
 * Bugfix: the popup tooltip was showing value of the sequence starting with the byte under cursor, as opposed to the value displayed under the cursor.  This change doesn't affect the 2-nibble (one byte) display mode (need before and after screenshots)
+* Bugfix (#79): better tracking of externally modified and deleted files
+* Bugfix (#77): correctly handling tab closure and therefore removing incorrect data persistency through tab closure and reopening
 * Build: fixed build by providing `null` arguments into `resolve()` -- the method requires one argument now
-* Dependency: now depending on hexy.js 0.3.3 (unpublished yet), which supports endianness and radix
+* Dependency: now depending on hexy 0.3.4, which supports endianness and radix
+* Dependency: no longer depending on `clipboardly` and native `fs` object -- replaced by vscode's alternatives that work better (some of the bugfixes above are attributed to this)
+* Fit and Finish: removed the "Show Hexdump" menu items from hexdump tabs
+* Version: updated version number
 
 ## [1.8.0] 2020-09-10
 * Fix update on save and on file changed (#17, [#66](https://github.com/stef-levesque/vscode-hexdump/issues/66), [#67](https://github.com/stef-levesque/vscode-hexdump/issues/67), thanks @joeywang4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.8.0] TBD
+++ endianness, ++ radix, ++ data size; -- few small bugs;
+details:
+* Enabled endianness of displayed data (the main reason behind the change) enabled by the added feature to hexy.js
+* Context Menu: added convenient switch of displaying between 1, 2, 4 and 8 byte words
+* New Functionality: added ability to display bytes as binary, octal, decimal and hexadecimal
+* Context Menu: the above functionality is also accessible via the context menu
+* Bugfix: endiannes was always set to "big", regardless of the UI setting in multi-byte displaying
+* Bugfix: fixed the meaning of endiannes that was incorrectly displayed in the status bar
+* Bugfix: the popup tooltip was showing value of the sequence starting with the byte under cursor, as opposed to the value displayed under the cursor.  This change doesn't affect the 2-nibble (one byte) display mode (need before and after screenshots)
+* Build: fixed build by providing `null` arguments into `resolve()` -- the method requires one argument now
+* Dependency: now depending on hexy.js 0.3.3 (unpublished yet), which supports endianness and radix
+
 ## [1.7.0] 2018-10-08
 * Copy selection in different formats (#41, #43, #47)
 * Add support for multi byte edit (#42, #45, thanks @noam787)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Colorize modified bytes
 
 ## Requirements
 
-Visual Studio Code v1.17.0
+Visual Studio Code v1.60.0
 
 ## Credits
 

--- a/package.json
+++ b/package.json
@@ -576,7 +576,6 @@
     "hexy": "^0.3.4",
     "iconv-lite": "^0.6.3",
     "long": "^4.0.0",
-    "nrf-intel-hex": "^1.3.0",
-    "sprintf-js": "^1.1.2"
+    "nrf-intel-hex": "^1.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-hexdump",
   "displayName": "hexdump for VSCode",
-  "description": "Display a specified file in hexadecimal",
+  "description": "Displays files in hex format",
   "version": "1.9.0",
   "publisher": "slevesque",
   "license": "LICENSE",
@@ -468,9 +468,14 @@
           "default": 2,
           "description": "Number of nibbles per group"
         },
-        "hexdump.radix" : {
+        "hexdump.radix": {
           "type": "number",
-          "enum": [2, 8, 10, 16],
+          "enum": [
+            2,
+            8,
+            10,
+            16
+          ],
           "default": 0,
           "description": "radix to use for displaying the binary data"
         },
@@ -538,17 +543,15 @@
     "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "devDependencies": {
-    "typescript": "^2.2.1",
-    "vscode": "^1.0.3",
-    "@types/node": "^6.0.46",
-    "@types/clipboardy": "^1.1.0"
+    "@types/node": "^17.0.0",
+    "@types/vscode": "^1.63.1",
+    "typescript": "^4.5.4"
   },
   "dependencies": {
-    "clipboardy": "^1.2.3",
-    "hexy": "^0.3.3",
-    "iconv-lite": "^0.4.24",
+    "hexy": "^0.3.4",
+    "iconv-lite": "^0.6.3",
+    "long": "^4.0.0",
     "nrf-intel-hex": "^1.3.0",
-    "sprintf-js": "^1.0.3",
-    "long": "^4.0.0"
+    "sprintf-js": "^1.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -357,41 +357,50 @@
       ],
       "editor/title/context": [
         {
-          "command": "hexdump.hexdumpFile"
+          "command": "hexdump.hexdumpFile",
+          "when": "hexdump:btnEnabled && resourceScheme == file"
         }
       ],
       "editor/context": [
         {
           "when": "editorLangId == hexdump",
-          "command": "hexdump.editValue"
+          "command": "hexdump.editValue",
+          "group": "edit"
         },
         {
           "when": "editorLangId == hexdump",
-          "command": "hexdump.gotoAddress"
+          "command": "hexdump.gotoAddress",
+          "group": "navigate"
         },
         {
           "when": "editorLangId == hexdump",
-          "command": "hexdump.searchString"
+          "command": "hexdump.searchString",
+          "group": "navigate"
         },
         {
           "when": "editorLangId == hexdump",
-          "command": "hexdump.searchHex"
+          "command": "hexdump.searchHex",
+          "group": "navigate"
         },
         {
           "when": "editorLangId == hexdump",
-          "command": "hexdump.exportToFile"
+          "command": "hexdump.exportToFile",
+          "group": "export"
         },
         {
           "when": "editorLangId == hexdump",
-          "command": "hexdump.toggleEndian"
+          "command": "hexdump.copyAsFormat",
+          "group": "export"
         },
         {
           "when": "editorLangId == hexdump",
-          "command": "hexdump.copyAsFormat"
+          "submenu": "hexdump.displayAs",
+          "group": "view"
         },
         {
           "when": "editorLangId == hexdump",
-          "submenu": "hexdump.displayAs"
+          "command": "hexdump.toggleEndian",
+          "group": "view"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "vscode-hexdump",
   "displayName": "hexdump for VSCode",
   "description": "Display a specified file in hexadecimal",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "publisher": "slevesque",
-  "license": "LICENSE.md",
+  "license": "LICENSE",
   "icon": "icon.png",
   "bugs": {
     "url": "https://github.com/stef-levesque/vscode-hexdump/issues"
@@ -19,7 +19,7 @@
     "theme": "dark"
   },
   "engines": {
-    "vscode": "^1.17.0"
+    "vscode": "^1.60.0"
   },
   "keywords": [
     "vscode",
@@ -38,6 +38,8 @@
       {
         "id": "hexdump",
         "extensions": [
+          ".bin",
+          ".hex",
           ".hexdump"
         ]
       }
@@ -97,57 +99,179 @@
         "when": "editorLangId == hexdump"
       },
       {
+        "command": "hexdump.showAsBytes",
+        "title": "as 8-bit, Single Bytes",
+        "when": "editorLangId == hexdump"
+      },
+      {
+        "command": "hexdump.showAsWords",
+        "title": "as 16-bit Words",
+        "when": "editorLangId == hexdump"
+      },
+      {
+        "command": "hexdump.showAsDwords",
+        "title": "as 32-bit Words",
+        "when": "editorLangId == hexdump"
+      },
+      {
+        "command": "hexdump.showAsQwords",
+        "title": "as 64-bit Words",
+        "when": "editorLangId == hexdump"
+      },
+      {
+        "command": "hexdump.showAsBin",
+        "title": "as Binary Numbers",
+        "when": "editorLangId == hexdump"
+      },
+      {
+        "command": "hexdump.showAsOct",
+        "title": "as Octal Numbers",
+        "when": "editorLangId == hexdump"
+      },
+      {
+        "command": "hexdump.showAsDec",
+        "title": "as Decimal Numbers",
+        "when": "editorLangId == hexdump"
+      },
+      {
+        "command": "hexdump.showAsHex",
+        "title": "as Hexadecimal Numbers",
+        "when": "editorLangId == hexdump"
+      },
+      {
         "command": "hexdump.copyAsFormat",
-        "title": "Copy the selection in a specific format",
+        "title": "Copy the Selection in a Specific Format",
         "when": "editorLangId == hexdump"
       },
       {
         "command": "hexdump.copyAsText",
-        "title": "Copy the buffer selection as text",
+        "title": "as Text",
         "when": "editorLangId == hexdump"
       },
       {
         "command": "hexdump.copyAsC",
-        "title": "Copy the buffer selection as C source",
+        "title": "as C Source",
         "when": "editorLangId == hexdump"
       },
       {
         "command": "hexdump.copyAsGolang",
-        "title": "Copy the buffer selection as Go source",
+        "title": "as Go Source",
         "when": "editorLangId == hexdump"
       },
       {
         "command": "hexdump.copyAsJava",
-        "title": "Copy the buffer selection as Java source",
+        "title": "as Java Source",
         "when": "editorLangId == hexdump"
       },
       {
         "command": "hexdump.copyAsJSON",
-        "title": "Copy the buffer selection as JSON",
+        "title": "as JSON",
         "when": "editorLangId == hexdump"
       },
       {
         "command": "hexdump.copyAsBase64",
-        "title": "Copy the buffer selection as Base64",
+        "title": "as Base64",
         "when": "editorLangId == hexdump"
       },
       {
         "command": "hexdump.copyAsHexString",
-        "title": "Copy the buffer selection as a hexadecimal string",
+        "title": "as a Hexadecimal String",
         "when": "editorLangId == hexdump"
       },
       {
         "command": "hexdump.copyAsLiteral",
-        "title": "Copy the buffer selection as a string literal",
+        "title": "as a String Literal",
         "when": "editorLangId == hexdump"
       },
       {
         "command": "hexdump.copyAsIntelHex",
-        "title": "Copy the buffer selection as Intel Hex",
+        "title": "as Intel Hex",
         "when": "editorLangId == hexdump"
       }
     ],
+    "submenus": [
+      {
+        "id": "hexdump.copyAs",
+        "label": "Copy As"
+      },
+      {
+        "id": "hexdump.displayAs",
+        "label": "Display As"
+      }
+    ],
     "menus": {
+      "hexdump.copyAs": [
+        {
+          "command": "hexdump.copyAsText",
+          "group": "hexdump.copy@0"
+        },
+        {
+          "command": "hexdump.copyAsC",
+          "group": "hexdump.copy@1"
+        },
+        {
+          "command": "hexdump.copyAsGolang",
+          "group": "hexdump.copy@2"
+        },
+        {
+          "command": "hexdump.copyAsJava",
+          "group": "hexdump.copy@3"
+        },
+        {
+          "command": "hexdump.copyAsJSON",
+          "group": "hexdump.copy@4"
+        },
+        {
+          "command": "hexdump.copyAsBase64",
+          "group": "hexdump.copy@5"
+        },
+        {
+          "command": "hexdump.copyAsHexString",
+          "group": "hexdump.copy@6"
+        },
+        {
+          "command": "hexdump.copyAsLiteral",
+          "group": "hexdump.copy@7"
+        },
+        {
+          "command": "hexdump.copyAsIntelHex",
+          "group": "hexdump.copy@8"
+        }
+      ],
+      "hexdump.displayAs": [
+        {
+          "command": "hexdump.showAsBytes",
+          "group": "hexdump.size@0"
+        },
+        {
+          "command": "hexdump.showAsWords",
+          "group": "hexdump.size@1"
+        },
+        {
+          "command": "hexdump.showAsDwords",
+          "group": "hexdump.size@2"
+        },
+        {
+          "command": "hexdump.showAsQwords",
+          "group": "hexdump.size@3"
+        },
+        {
+          "command": "hexdump.showAsBin",
+          "group": "hexdump.radix@0"
+        },
+        {
+          "command": "hexdump.showAsOct",
+          "group": "hexdump.radix@1"
+        },
+        {
+          "command": "hexdump.showAsDec",
+          "group": "hexdump.radix@2"
+        },
+        {
+          "command": "hexdump.showAsHex",
+          "group": "hexdump.radix@3"
+        }
+      ],
       "commandPalette": [
         {
           "command": "hexdump.editValue",
@@ -264,6 +388,10 @@
         {
           "when": "editorLangId == hexdump",
           "command": "hexdump.copyAsFormat"
+        },
+        {
+          "when": "editorLangId == hexdump",
+          "submenu": "hexdump.displayAs"
         }
       ]
     },
@@ -334,10 +462,17 @@
           "enum": [
             2,
             4,
-            8
+            8,
+            16
           ],
           "default": 2,
-          "description": "How many nibbles per group"
+          "description": "Number of nibbles per group"
+        },
+        "hexdump.radix" : {
+          "type": "number",
+          "enum": [2, 8, 10, 16],
+          "default": 0,
+          "description": "radix to use for displaying the binary data"
         },
         "hexdump.uppercase": {
           "type": "boolean",
@@ -410,7 +545,7 @@
   },
   "dependencies": {
     "clipboardy": "^1.2.3",
-    "hexy": "^0.2.10",
+    "hexy": "^0.3.3",
     "iconv-lite": "^0.4.24",
     "nrf-intel-hex": "^1.3.0",
     "sprintf-js": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,11 @@
         "when": "editorLangId == hexdump"
       },
       {
+        "command": "hexdump.toggleUppercase",
+        "title": "Toggle Between Upper- and Lowercase",
+        "when": "editorLangId == hexdump"
+      },
+      {
         "command": "hexdump.searchString",
         "title": "Search a string in the file",
         "when": "editorLangId == hexdump"
@@ -401,6 +406,11 @@
           "when": "editorLangId == hexdump",
           "command": "hexdump.toggleEndian",
           "group": "view"
+        },
+        {
+          "when": "editorLangId == hexdump",
+          "command": "hexdump.toggleUppercase",
+          "group": "view"
         }
       ]
     },
@@ -436,6 +446,12 @@
         "key": "shift+alt+ctrl+e",
         "mac": "shift+alt+cmd+e",
         "command": "hexdump.toggleEndian",
+        "when": "editorLangId == hexdump"
+      },
+      {
+        "key": "shift+alt+ctrl+u",
+        "mac": "shift+alt+cmd+u",
+        "command": "hexdump.toggleUppercase",
         "when": "editorLangId == hexdump"
       },
       {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-hexdump",
   "displayName": "hexdump for VSCode",
   "description": "Display a specified file in hexadecimal",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "publisher": "slevesque",
   "license": "LICENSE",
   "icon": "icon.png",
@@ -404,7 +404,7 @@
       {
         "key": "shift+enter",
         "command": "hexdump.editValue",
-        "when": "editorTextFocus"
+        "when": "editorTextFocus && editorLangId == hexdump"
       },
       {
         "key": "ctrl+g",

--- a/src/contentProvider.ts
+++ b/src/contentProvider.ts
@@ -1,7 +1,6 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { sprintf } from 'sprintf-js';
 
 import { getEntry, Format, getHexyFormat } from './util';
 
@@ -38,7 +37,7 @@ export default class HexdumpContentProvider implements vscode.TextDocumentConten
         return new Promise( async (resolve) => {
             const entry = await getEntry(uri);
             const format = entry.format;
-            const header = format.showAddress ? this.getHeader(format) : '';
+            const header = format.showOffset ? this.getHeader(format) : '';
             const tail = "(Reached the maximum size to display. You can change `hexdump.sizeDisplay` in your settings.)";
 
             if (entry.isDeleted || !entry.data) {
@@ -61,7 +60,7 @@ export default class HexdumpContentProvider implements vscode.TextDocumentConten
                     }
                     return resolve(hexString);
                 } else {
-                    return resolve("(hexdump cancelled.)"); // TODO: remove this by only coverting the visible part + delta
+                    return resolve("(hexdump cancelled.)");
                 }
             }
         });
@@ -92,7 +91,7 @@ export default class HexdumpContentProvider implements vscode.TextDocumentConten
                 } else {
                     column += ii;
                 }
-                header += sprintf("%02X", column);
+                header += column.toString(16).padStart(2, "0");
             }
         }
 

--- a/src/contentProvider.ts
+++ b/src/contentProvider.ts
@@ -83,16 +83,23 @@ export default class HexdumpContentProvider implements vscode.TextDocumentConten
     private getHeader(): string {
         const config = vscode.workspace.getConfiguration('hexdump');
         let header = config['showAddress'] ? "  Offset:" : "";
+        let line_width = config['width'];
         let group_size = config['nibbles'] / 2;
         let radix = config['radix'];
-        let group_len = hexy.maxnumberlen(group_size, radix)
-        for (var i = 0; i < config['width']; ++i) {
-            if (i % (config['nibbles'] / 2) == 0) {
-                for (var c = 0; c < 1 + group_len - group_size * 2; c++) {
-                    header += " ";
+        let littleEndian = config['littleEndian'];
+        let group_len = hexy.maxnumberlen(group_size, radix);
+
+        for (var group = 0; group < line_width / group_size; group++) {
+            header += " ".repeat(1 + group_len - (group_size * 2));
+            for (var ii = 0; ii < group_size; ii++) {
+                let column = group * group_size;
+                if (littleEndian) {
+                    column += group_size - ii - 1;
+                } else {
+                    column += ii;
                 }
+                header += sprintf('%02X', column);
             }
-            header += sprintf('%02X', i);
         }
 
         header += "\t\n";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -297,6 +297,16 @@ export function activate(context: vscode.ExtensionContext) {
         }
     }));
 
+    context.subscriptions.push(vscode.commands.registerCommand('hexdump.toggleUppercase', async () => {
+        let d = vscode.window.activeTextEditor.document;
+        if (d.uri.scheme === 'hexdump') {
+            let entry = await getEntry(d.uri);
+            entry.format.uppercase = !entry.format.uppercase;
+            HexdumpContentProvider.instance.update(fakeUri(d.uri));
+            statusBar.update();
+        }
+    }));
+
     context.subscriptions.push(vscode.commands.registerCommand('hexdump.toggleCollapsing', async () => {
         let d = vscode.window.activeTextEditor.document;
         if (d.uri.scheme === 'hexdump') {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,14 +6,16 @@ import * as MemoryMap from 'nrf-intel-hex';
 import HexdumpContentProvider from './contentProvider';
 import HexdumpHoverProvider from './hoverProvider';
 import HexdumpStatusBar from './statusBar';
-import { getEntry, getOffset, getPosition, getRanges, triggerUpdateDecorations, onDocumentClosed, getBufferSelection, realUri, fakeUri } from './util';
+import { getEntry, getOffset, getPosition, getRanges, triggerUpdateDecorations, onDocumentClosed, getBufferSelection, initMemento, realUri, fakeUri } from './util';
 
 export function activate(context: vscode.ExtensionContext) {
     const config = vscode.workspace.getConfiguration('hexdump');
     const charEncoding: BufferEncoding = config['charEncoding'];
     const btnEnabled: string = config['btnEnabled'];
 
-    let statusBar = new HexdumpStatusBar();
+    initMemento(context);
+
+    const statusBar = new HexdumpStatusBar();
     context.subscriptions.push(statusBar);
 
     const smallDecorationType = vscode.window.createTextEditorDecorationType({

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,8 +68,7 @@ export function activate(context: vscode.ExtensionContext) {
             }
 
             var buf = getBuffer(e.textEditor.document.uri);
-            if (buf)
-            {
+            if (buf) {
                 if (startOffset >= buf.length) {
                     startOffset = buf.length - 1;
                 }
@@ -142,7 +141,6 @@ export function activate(context: vscode.ExtensionContext) {
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand('hexdump.hexdumpFile', (fileUri) => {
-
         if (typeof fileUri == 'undefined' || !(fileUri instanceof vscode.Uri)) {
             if (vscode.window.activeTextEditor === undefined) {
                 vscode.commands.executeCommand('hexdump.hexdumpPath');
@@ -162,11 +160,9 @@ export function activate(context: vscode.ExtensionContext) {
             }
 
             vscode.commands.executeCommand("vscode.open", vscode.Uri.file(filePath));
-
         } else {
             hexdumpFile(fileUri.fsPath);
         }
-
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand('hexdump.editValue', () => {
@@ -306,7 +302,6 @@ export function activate(context: vscode.ExtensionContext) {
         });
     }));
 
-
     context.subscriptions.push(vscode.commands.registerCommand('hexdump.save', () => {
         let e = vscode.window.activeTextEditor;
         let d = e.document;
@@ -330,13 +325,67 @@ export function activate(context: vscode.ExtensionContext) {
             triggerUpdateDecorations(e);
             vscode.window.setStatusBarMessage('Hexdump: exported to ' + filepath, 3000);
         });
-
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand('hexdump.toggleEndian', () => {
         let config = vscode.workspace.getConfiguration('hexdump');
         const littleEndian = config.get('littleEndian');
         config.update('littleEndian', !littleEndian);
+        statusBar.update();
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('hexdump.toggleCollapsing', () => {
+        let config = vscode.workspace.getConfiguration('hexdump');
+        const collapseContiguous = config.get('collapseContiguous');
+        config.update('collapseContiguous', !collapseContiguous);
+        statusBar.update();
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('hexdump.showAsBytes', () => {
+        let config = vscode.workspace.getConfiguration('hexdump');
+        config.update('nibbles', 2);
+        statusBar.update();
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('hexdump.showAsWords', () => {
+        let config = vscode.workspace.getConfiguration('hexdump');
+        config.update('nibbles', 4);
+        statusBar.update();
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('hexdump.showAsDwords', () => {
+        let config = vscode.workspace.getConfiguration('hexdump');
+        config.update('nibbles', 8);
+        statusBar.update();
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('hexdump.showAsQwords', () => {
+        let config = vscode.workspace.getConfiguration('hexdump');
+        config.update('nibbles', 16);
+        statusBar.update();
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('hexdump.showAsBin', () => {
+        let config = vscode.workspace.getConfiguration('hexdump');
+        config.update('radix', 2);
+        statusBar.update();
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('hexdump.showAsOct', () => {
+        let config = vscode.workspace.getConfiguration('hexdump');
+        config.update('radix', 8);
+        statusBar.update();
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('hexdump.showAsDec', () => {
+        let config = vscode.workspace.getConfiguration('hexdump');
+        config.update('radix', 10);
+        statusBar.update();
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('hexdump.showAsHex', () => {
+        let config = vscode.workspace.getConfiguration('hexdump');
+        config.update('radix', 16);
         statusBar.update();
     }));
 
@@ -545,7 +594,7 @@ export function activate(context: vscode.ExtensionContext) {
             clipboardy.write(buffer.toString('hex'));
         }
     }));
-    
+
     context.subscriptions.push(vscode.commands.registerCommand('hexdump.copyAsLiteral', () => {
         let e = vscode.window.activeTextEditor;
         let buffer = getBufferSelection(e.document, e.selection);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import * as MemoryMap from 'nrf-intel-hex';
 import HexdumpContentProvider from './contentProvider';
 import HexdumpHoverProvider from './hoverProvider';
 import HexdumpStatusBar from './statusBar';
-import { getEntry, getOffset, getPosition, getRanges, triggerUpdateDecorations, getBufferSelection, realUri, fakeUri } from './util';
+import { getEntry, getOffset, getPosition, getRanges, triggerUpdateDecorations, onDocumentClosed, getBufferSelection, realUri, fakeUri } from './util';
 
 export function activate(context: vscode.ExtensionContext) {
     const config = vscode.workspace.getConfiguration('hexdump');
@@ -98,10 +98,16 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider('hexdump', provider));
 
     vscode.window.onDidChangeActiveTextEditor(e => {
-            if (e && e.document && e.document.uri.scheme === 'hexdump') {
-                triggerUpdateDecorations(e);
-            }
-        }, null, context.subscriptions);
+        if (e && e.document && e.document.uri.scheme === 'hexdump') {
+            triggerUpdateDecorations(e);
+        }
+    }, null, context.subscriptions);
+
+    vscode.workspace.onDidCloseTextDocument(doc => {
+        if (doc && doc.uri.scheme === 'hexdump') {
+            onDocumentClosed(doc);
+        }
+    }, null, context.subscriptions);
 
     context.subscriptions.push(vscode.commands.registerCommand('hexdump.hexdumpPath', () => {
             // Display a message box to the user

--- a/src/hoverProvider.ts
+++ b/src/hoverProvider.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 import { sprintf } from 'sprintf-js';
 import * as Long from 'long';
 
-var iconvLite = require('iconv-lite');
+const iconvLite = require('iconv-lite');
 
 import { getEntry, getOffset } from './util';
 
@@ -29,7 +29,7 @@ export default class HexdumpHoverProvider implements vscode.HoverProvider {
 
             offset = (offset >> (nibbles >> 2)) << (nibbles >> 2); // aligning the `offset` with the start of the displayed number
 
-            var content: string = 'Hex Inspector';
+            let content: string = 'Hex Inspector';
             content += littleEndian ? ' Little Endian\n' : ' Big Endian\n';
             content += 'Address: 0x' + sprintf('%08X', offset) + '\n';
 

--- a/src/hoverProvider.ts
+++ b/src/hoverProvider.ts
@@ -1,7 +1,6 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { sprintf } from 'sprintf-js';
 import * as Long from 'long';
 
 const iconvLite = require('iconv-lite');
@@ -14,55 +13,62 @@ export default class HexdumpHoverProvider implements vscode.HoverProvider {
 
     public async provideHover(document, position, token) : Promise<vscode.Hover> { 
         return new Promise<vscode.Hover>(async resolve => {
-            const charEncoding = vscode.workspace.getConfiguration('hexdump').get<string>('charEncoding');
-            const littleEndian = vscode.workspace.getConfiguration('hexdump').get<boolean>('littleEndian');
-            const nibbles = vscode.workspace.getConfiguration('hexdump').get<number>('nibbles');
             const showInspector = vscode.workspace.getConfiguration('hexdump').get<boolean>('showInspector');
-
+            const charEncoding = vscode.workspace.getConfiguration('hexdump').get<string>('charEncoding');
             if (!showInspector) {
                 return resolve(null);
             }
-            let offset = getOffset(position);
+
+            const entry = await getEntry(document.uri);
+            const f = entry.format;
+            let offset = getOffset(entry, position);
             if (typeof offset == 'undefined') {
                 return resolve(null);
             }
 
-            offset = (offset >> (nibbles >> 2)) << (nibbles >> 2); // aligning the `offset` with the start of the displayed number
-
-            let content: string = 'Hex Inspector';
-            content += littleEndian ? ' Little Endian\n' : ' Big Endian\n';
-            content += 'Address: 0x' + sprintf('%08X', offset) + '\n';
+            let content: string = "Hex Inspector";
+            content += (f.littleEndian ? " Little" : " Big") + " Endian\n";
+            content += "Address: 0x" + offset.toString(16).padStart(8, "0") + "\n";
 
             let sel = vscode.window.activeTextEditor.selection;
             if (sel.contains(position)) {
-                let start = getOffset(sel.start);
-                let end = getOffset(sel.end);
-                content += 'Selection: 0x' + sprintf('%08X', start);
-                content += ' - 0x' + sprintf('%08X', end) + ' \n';
+                let start = getOffset(entry, sel.start);
+                let end = getOffset(entry, sel.end);
+                content += "Selection: 0x" + start.toString(16).padStart(8, "0");
+                content += " - 0x" + end.toString(16).padStart(8, "0") + "\n";
+                content += ""
             }
 
-            let array = (await getEntry(document.uri)).data;
+            let array = entry.data;
             if (array === undefined) {
                 return resolve(null);
             }
 
             const view = new DataView(array.buffer, offset);
 
-            content += 'Int8:   ' + sprintf('%12d', view.getInt8(0)) + '\t'; // TODO: consistency++
-            content += 'Uint8:  ' + sprintf('%12d', view.getUint8(0)) + ' \n';
-            content += 'Int16:  ' + sprintf('%12d', view.getInt16(0, littleEndian)) + '\t';
-            content += 'Uint16: ' + sprintf('%12d', view.getUint16(0, littleEndian)) + ' \n';
-            content += 'Int32:  ' + sprintf('%12d', view.getInt32(0, littleEndian)) + '\t';
-            content += 'Uint32: ' + sprintf('%12d', view.getUint32(0, littleEndian)) + ' \n';
-            content += 'Int64:  ' + Long.fromBytes(array, true, littleEndian).toString() + ' \n';
-            content += 'Uint64: ' + Long.fromBytes(array, false, littleEndian).toString() + ' \n';
-            content += 'Float32: ' + sprintf('%f', view.getFloat32(0, littleEndian)) + ' \n';
-            content += 'Float64: ' + sprintf('%f', view.getFloat64(0, littleEndian)) + ' \n';
+            const int8 = view.getInt8(0);
+            content += "Int8:   " + int8.toString().padStart(21, " ") + "                " + (int8 < 0 ? "(-0x" : " (0x") + Math.abs(int8).toString(16).padStart(2, "0") + ")\n";
+            const uint8 = view.getUint8(0);
+            content += "Uint8:  " + uint8.toString().padStart(21, " ") + "                 (0x" + uint8.toString(16).padStart(2, "0") + ")\n";
+            const int16 = view.getInt16(0, f.littleEndian);
+            content += "Int16:  " + int16.toString().padStart(21, " ") + "              " + (int16 < 0 ? "(-0x" : " (0x") + Math.abs(int16).toString(16).padStart(4, "0") + ")\n";
+            const uint16 = view.getUint16(0, f.littleEndian);
+            content += "Uint16: " + uint16.toString().padStart(21, " ") + "               (0x" + uint16.toString(16).padStart(4, "0") + ")\n";
+            const int32 = view.getInt32(0, f.littleEndian);
+            content += "Int32:  " + int32.toString().padStart(21, " ") + "          " + (int32 < 0 ? "(-0x" : " (0x") + Math.abs(int32).toString(16).padStart(8, "0") + ")\n";
+            const uint32 = view.getUint32(0, f.littleEndian);
+            content += "Uint32: " + uint32.toString().padStart(21, " ") + "           (0x" + uint32.toString(16).padStart(8, "0") + ")\n";
+            const int64 = Long.fromBytes(array.slice(offset), false, f.littleEndian)
+            content += "Int64:  " + int64.toString().padStart(21, " ") + (int64.isNegative() ? "  (-0x" : "   (0x") + (int64.isNegative() ? int64.negate() : int64).toString(16).padStart(16, "0") + ")\n";
+            const uint64 = Long.fromBytes(array.slice(offset), true, f.littleEndian)
+            content += "Uint64: " + uint64.toString().padStart(21, " ") + "   (0x" + uint64.toString(16).padStart(16, "0") + ")\n";
+            content += 'Float32: ' + view.getFloat32(0, f.littleEndian).toString() + ' \n';
+            content += 'Float64: ' + view.getFloat64(0, f.littleEndian).toString() + ' \n';
             content += '\n';
 
             if (sel.contains(position)) {
-                let start = getOffset(sel.start);
-                let end = getOffset(sel.end) + 1;
+                let start = getOffset(entry, sel.start);
+                let end = getOffset(entry, sel.end) + 1;
                 content += 'String (' + charEncoding + '):\n';
                 let conv = iconvLite.decode(array.slice(start, end), charEncoding);
                 content += conv.toString();

--- a/src/hoverProvider.ts
+++ b/src/hoverProvider.ts
@@ -18,15 +18,18 @@ export default class HexdumpHoverProvider {
         return new Promise<vscode.Hover>((resolve) => {
             const charEncoding = vscode.workspace.getConfiguration('hexdump').get<string>('charEncoding');
             const littleEndian = vscode.workspace.getConfiguration('hexdump').get<boolean>('littleEndian');
+            const nibbles = vscode.workspace.getConfiguration('hexdump').get<number>('nibbles');
             const showInspector = vscode.workspace.getConfiguration('hexdump').get<boolean>('showInspector');
 
             if (!showInspector) {
-                return resolve();
+                return resolve(null);
             }
             let offset = getOffset(position);
             if (typeof offset == 'undefined') {
-                return resolve();
+                return resolve(null);
             }
+
+            offset = (offset >> (nibbles >> 2)) << (nibbles >> 2); // aligning the `offset` with the start of the displayed number
 
             var content: string = 'Hex Inspector';
             content += littleEndian ? ' Little Endian\n' : ' Big Endian\n';
@@ -42,7 +45,7 @@ export default class HexdumpHoverProvider {
 
             let buf = getBuffer(document.uri);
             if (typeof buf == 'undefined') {
-                return resolve();
+                return resolve(null);
             }
 
             let arrbuf = toArrayBuffer(buf, offset, 8);

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -54,9 +54,25 @@ export default class HexdumpStatusBar {
             const entry = getEntry(this._currentDocument.document.uri);
             let littleEndian = (await entry).format.littleEndian;
             let uppercase = (await entry).format.uppercase;
+            let radix: string = "hex";
+            switch ((await entry).format.radix) {
+            case 2:
+                radix = "bin";
+                break;
+            case 8:
+                radix = "oct";
+                break;
+            case 10:
+                radix = "dec";
+                break;
+            default:
+                radix = "hex";
+                break;
+            }
 
-            this._statusBarItem.text = (uppercase ? "HEX" : "hex") + " " + (littleEndian ? "LE" : "BE");
-            this._statusBarItem.tooltip = (uppercase ? "Upper" : "Lower") + " Case, "
+            this._statusBarItem.text = (uppercase ? radix.toUpperCase() : radix) + " " + (littleEndian ? "LE" : "BE");
+            this._statusBarItem.tooltip = (uppercase ? "Upper" : "Lower") + " Case, \n"
+                                        + radix + "\n"
                                         + (littleEndian ? "Little" : "Big") + " Endian";
 
             let e = vscode.window.activeTextEditor;

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -5,7 +5,6 @@ import * as vscode from 'vscode';
 import { getEntry } from './util';
 
 export default class HexdumpStatusBar {
-
     private static s_instance: HexdumpStatusBar = null;
     private _statusBarItem: vscode.StatusBarItem;
     private _disposables: vscode.Disposable[] = [];
@@ -17,7 +16,7 @@ export default class HexdumpStatusBar {
 
         this._statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right);
 
-        vscode.window.onDidChangeActiveTextEditor((e) => {
+        vscode.window.onDidChangeActiveTextEditor(e => {
             if (e && e.document.languageId === 'hexdump') {
                 this._statusBarItem.show();
             } else {
@@ -38,15 +37,15 @@ export default class HexdumpStatusBar {
             HexdumpStatusBar.s_instance.dispose();
             HexdumpStatusBar.s_instance = null;
         }
-		this._disposables.forEach(d => d.dispose());
-		this._disposables = [];
+        this._disposables.forEach(d => d.dispose());
+        this._disposables = [];
     }
 
     get Item() {
         return this._statusBarItem;
     }
 
-    public update() {
+    public async update() {
         let littleEndian = vscode.workspace.getConfiguration('hexdump').get('littleEndian');
         let uppercase = vscode.workspace.getConfiguration('hexdump').get('uppercase');
 
@@ -55,9 +54,8 @@ export default class HexdumpStatusBar {
                                     + (littleEndian ? 'Little' : 'Big') + ' Endian';
 
         let e = vscode.window.activeTextEditor;
-        // check if hexdump document
         if (e && e.document.uri.scheme === 'hexdump') {
-            if (getEntry(e.document.uri).isDirty) {
+            if ((await getEntry(e.document.uri)).isDirty) {
                 this._statusBarItem.text += ' (modified)';
             }
         }

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -26,7 +26,6 @@ export default class HexdumpStatusBar {
         }, null, this._disposables);
 
         HexdumpStatusBar.s_instance = this;
-
     }
 
     static get instance() {
@@ -49,9 +48,11 @@ export default class HexdumpStatusBar {
 
     public update() {
         let littleEndian = vscode.workspace.getConfiguration('hexdump').get('littleEndian');
+        let uppercase = vscode.workspace.getConfiguration('hexdump').get('uppercase');
 
-        this._statusBarItem.text = littleEndian ? 'hex' : 'HEX';
-        this._statusBarItem.tooltip = littleEndian ? 'Little Endian' : 'Big Endian';
+        this._statusBarItem.text = (uppercase ? 'HEX' : 'hex') + ' ' + (littleEndian ? 'LE' : 'BE');
+        this._statusBarItem.tooltip = (uppercase ? 'Upper' : 'Lower') + ' Case, '
+                                    + (littleEndian ? 'Little' : 'Big') + ' Endian';
 
         let e = vscode.window.activeTextEditor;
         // check if hexdump document


### PR DESCRIPTION

details:
* Enabled endianness of displayed data (the main reason behind the change) enabled by the added feature to hexy.js
* Context Menu: added convenient switch of displaying between 1, 2, 4 and 8 byte words
* New Fx: added ability to display bytes as binary, octal, decimal and hexadecimal
* New Fx (issue #59): each file can have its own view settings
* New Fx: the file view settings are now persistent through the app sessions
* Context Menu: the above functionality is also accessible via the context menu
* Bugfix: endiannes was always set to "big", regardless of the UI setting in multi-byte displaying
* Bugfix: fixed the meaning of endiannes that was incorrectly displayed in the status bar
* Bugfix: the popup tooltip was showing value of the sequence starting with the byte under cursor, as opposed to the value displayed under the cursor.  This change doesn't affect the 2-nibble (one byte) display mode (need before and after screenshots)
* Bugfix (#79): better tracking of externally modified and deleted files
* Bugfix (#77): correctly handling tab closure and therefore removing incorrect data persistency through tab closure and reopening
* Fixes in hover window:
  * corrected offset calculation for LE mode
  * Int64 and Uint64 values were always the same regardless the position of the cursor
  * Int64 and Uint64 were swapped around: uint was read as signed, and int was read as unsigned
* Build: fixed build by providing `null` arguments into `resolve()` -- the method requires one argument now
* Dependency: now depending on hexy 0.3.4, which supports endianness and radix
* Dependency: no longer depending on `clipboardly`, `sprintf-js`, and native `fs` objects -- replaced by vscode's alternatives that work better (some of the bugfixes above are attributed to this)
* Fit and Finish: removed the "Show Hexdump" menu items from hexdump tabs
* Other: pulled the changes that are currently present in VS Code distribution, but not in master branch yet (version 1.8.0)
* Version: updated version number